### PR TITLE
Headers conflict

### DIFF
--- a/clubhouse/clubhouse.py
+++ b/clubhouse/clubhouse.py
@@ -91,6 +91,7 @@ class Clubhouse:
         """ (Clubhouse, str, str, str) -> NoneType
         Set authenticated information
         """
+        self.HEADERS = dict(self.HEADERS)
         self.HEADERS['CH-UserID'] = user_id if user_id else "(null)"
         if user_token:
             self.HEADERS['Authorization'] = f"Token {user_token}"

--- a/clubhouse/clubhouse.py
+++ b/clubhouse/clubhouse.py
@@ -88,10 +88,12 @@ class Clubhouse:
         return wrap
 
     def __init__(self, user_id='', user_token='', user_device='', headers=None):
-        """ (Clubhouse, str, str, str) -> NoneType
+        """ (Clubhouse, str, str, str, dict) -> NoneType
         Set authenticated information
         """
-        self.HEADERS = dict(headers) if isinstance(headers, dict) else dict(self.HEADERS)
+        self.HEADERS = dict(self.HEADERS)
+        if isinstance(headers, dict):
+            self.HEADERS.update(headers)
         self.HEADERS['CH-UserID'] = user_id if user_id else "(null)"
         if user_token:
             self.HEADERS['Authorization'] = f"Token {user_token}"

--- a/clubhouse/clubhouse.py
+++ b/clubhouse/clubhouse.py
@@ -87,11 +87,11 @@ class Clubhouse:
             return func(self, *args, **kwargs)
         return wrap
 
-    def __init__(self, user_id='', user_token='', user_device=''):
+    def __init__(self, user_id='', user_token='', user_device='', headers=None):
         """ (Clubhouse, str, str, str) -> NoneType
         Set authenticated information
         """
-        self.HEADERS = dict(self.HEADERS)
+        self.HEADERS = dict(headers) if isinstance(headers, dict) else dict(self.HEADERS)
         self.HEADERS['CH-UserID'] = user_id if user_id else "(null)"
         if user_token:
             self.HEADERS['Authorization'] = f"Token {user_token}"


### PR DESCRIPTION
- [x] Extract headers per instance

  - This code can help to use multi account from this class as multi instance.
  - Before this only one account can be used because the dictionary(HEADERS) as an attribute of class has the same value for all instances.
  - Therefore, the auth specific to each instance cannot be stored separately.

- [x] Add custom header

  - Custom header as class parameter can be used when user saved Headers.